### PR TITLE
Updated urls.py to use new-style imports.

### DIFF
--- a/robots/urls.py
+++ b/robots/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns('robots.views',
     url(r'^$', 'rules_list', name='robots_rule_list'),


### PR DESCRIPTION
With the release of Django 1.5, the import format for urls.py now raises a noisy warning. Supporting the older format is no longer required, as all the officially supported versions of Django now provide the new format.
