### PR TITLE
update url import statement for compatibility

### DIFF
--- a/robots/urls.py
+++ b/robots/urls.py
@@ -1,5 +1,6 @@
-from django.conf.urls import patterns, url
+from django.conf.urls.defaults import *
 
-urlpatterns = patterns('robots.views',
+urlpatterns = patterns(
+    'robots.views',
     url(r'^$', 'rules_list', name='robots_rule_list'),
 )


### PR DESCRIPTION
"cannot import name patterns" error occurs with existing code using Django 1.3.1
Please merge this update and update the egg.
See http://stackoverflow.com/questions/8074955/cannot-import-name-patterns for details.
