### PR TITLE
RuleAdmin - search_fields bug fix

### DIFF
--- a/robots/admin.py
+++ b/robots/admin.py
@@ -19,7 +19,7 @@ class RuleAdmin(admin.ModelAdmin):
     )
     list_filter = ('sites',)
     list_display = ('robot', 'allowed_urls', 'disallowed_urls')
-    search_fields = ('robot', 'urls')
+    search_fields = ('robot', 'allowed__pattern', 'disallowed__pattern')
 
 admin.site.register(Url)
 admin.site.register(Rule, RuleAdmin)


### PR DESCRIPTION
Exception when searching in the admin:

```
FieldError at /admin/robots/rule/
Cannot resolve keyword 'urls' into field. Choices are: allowed, crawl_delay, disallowed, id, robot, sites
```
