### PR TITLE
get_sitemap_urls no longer modifies SITEMAP_URLS

### DIFF
--- a/robots/views.py
+++ b/robots/views.py
@@ -30,7 +30,7 @@ class RuleList(ListView):
                 pass
 
     def get_sitemap_urls(self):
-        sitemap_urls = settings.SITEMAP_URLS
+        sitemap_urls = list(settings.SITEMAP_URLS)
 
         if not sitemap_urls and settings.USE_SITEMAP:
             scheme = self.request.is_secure() and 'https' or 'http'


### PR DESCRIPTION
See #37 for background.

I ended up going for `sitemap_urls = list(settings.SITEMAP_URLS)` instead of `sitemap_urls = settings.SITEMAP_URLS[::]` because the latter would not work if a user made `SITEMAP_URLS` a tuple.

Fix #37 