### PR TITLE
Fix warnings about URLconf in Django 1.9

### DIFF
--- a/robots/urls.py
+++ b/robots/urls.py
@@ -1,9 +1,8 @@
-try:
-    from django.conf.urls import patterns, url
-except ImportError:
-    from django.conf.urls.defaults import patterns, url
+from django.conf.urls import url
 
-urlpatterns = patterns(
-    'robots.views',
-    url(r'^$', 'rules_list', name='robots_rule_list'),
-)
+from robots.views import rules_list
+
+
+urlpatterns = [
+    url(r'^$', rules_list, name='robots_rule_list'),
+]


### PR DESCRIPTION
This PR fixes the following warnings when using Django 1.9:

* django.conf.urls.patterns will be removed in Django 1.10
* Passing a dotted path and not a view function will be deprecated in
  Django 1.10

I also removed the `try: ... except:` statement since the `url()` function has been available at `django.conf.urls` since Django 1.4.