### PR TITLE
Detect current site via http host var

### DIFF
--- a/robots/settings.py
+++ b/robots/settings.py
@@ -7,3 +7,5 @@ SITEMAP_URLS.extend(getattr(settings, 'ROBOTS_SITEMAP_URLS', []))
 USE_SITEMAP = getattr(settings, 'ROBOTS_USE_SITEMAP', True)
 
 CACHE_TIMEOUT = getattr(settings, 'ROBOTS_CACHE_TIMEOUT', None)
+
+SITE_BY_REQUEST = getattr(settings, 'ROBOTS_SITE_BY_REQUEST', False)

--- a/robots/views.py
+++ b/robots/views.py
@@ -18,7 +18,10 @@ class RuleList(ListView):
     cache_timeout = settings.CACHE_TIMEOUT
 
     def get_current_site(self, request):
-        return Site.objects.get_current()
+        if settings.SITE_BY_REQUEST:
+            return Site.objects.get(domain=request.get_host())
+        else:
+            return Site.objects.get_current()
 
     def reverse_sitemap_url(self):
         try:


### PR DESCRIPTION
Hi guys,

In addition to default Django's site detection by SITE_ID from settings.py I want to add support of dynamic site detection mechanism. It is very usefull when you does not have separate settings.py per-site but want to serve multiple sites on single Django instance. In my case it is Mezzanine CMS which has native multisite without per-site settings support and I want to run django-robots same way.
This solution is not Mezzanine specific, it is pretty universal.
Lets try to merge it =)