### PR TITLE
Fix rule to allow all robots complete access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 /dist
 .tox
 .coverage
+.DS_Store

--- a/robots/templates/robots/rule_list.html
+++ b/robots/templates/robots/rule_list.html
@@ -4,7 +4,7 @@
 {% endfor %}{% for url in rule.disallowed.all %}Disallow: {{ url.pattern|safe }}
 {% endfor %}{% if rule.crawl_delay %}Crawl-delay: {% localize off %}{{ rule.crawl_delay|floatformat:'0' }}{% endlocalize %}
 {% endif %}{% endfor %}{% else %}User-agent: *
-Allow: /
+Disallow:
 {% endif %}
 {% if host %}Host: {{ host }}{% endif %}
 {% for sitemap_url in sitemap_urls %}Sitemap: {{ sitemap_url }}


### PR DESCRIPTION
Invalid syntax
```
User-agent: *
Allow: /
```
To allow all robots complete access
```
User-agent: *
Disallow:
```
For more details please see http://www.robotstxt.org/robotstxt.html