### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ This is a basic Django application to manage robots.txt files following the
 For installation instructions, see the documentation `install section`_;
 for instructions on how to use this application, and on
 what it provides, see the file "overview.txt" in the "docs/"
-directory or on ReadTheDocs: http://django-robots.readthedocs.org/
+directory or on ReadTheDocs: https://django-robots.readthedocs.io/
 
 
 Supported Django versions
@@ -30,7 +30,7 @@ Supported Python version
 * Python 3.3, 3.4, 3.5
 
 
-.. _install section: http://django-robots.readthedocs.org/en/latest/#installation
+.. _install section: https://django-robots.readthedocs.io/en/latest/#installation
 .. _robots exclusion protocol: http://en.wikipedia.org/wiki/Robots_exclusion_standard
 .. _Django: http://www.djangoproject.com/
 .. _Sitemap contrib app: http://docs.djangoproject.com/en/dev/ref/contrib/sitemaps/


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.