### PR TITLE
Drop older Django versions, add new ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 python:
+- 3.6
 - 3.5
 - 3.4
 - 3.3
@@ -9,10 +10,10 @@ env:
   matrix:
   - TOXENV='pep8'
   - TOXENV='isort'
+  - DJANGO='django111'
+  - DJANGO='django110'
   - DJANGO='django19'
   - DJANGO='django18'
-  - DJANGO='django17'
-  - DJANGO='django16'
 install:
 - pip install -U tox>=1.8 codecov
 - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi
@@ -32,6 +33,10 @@ matrix:
   - python: 3.3
     env: DJANGO='django19'
   - python: 3.3
+    env: DJANGO='django110'
+  - python: 3.3
+    env: DJANGO='django111'
+  - python: 3.3
     env: TOXENV='pep8'
   - python: 3.3
     env: TOXENV='isort'
@@ -40,8 +45,16 @@ matrix:
   - python: 3.4
     env: TOXENV='isort'
   - python: 3.5
+    env: TOXENV='pep8'
+  - python: 3.5
+    env: TOXENV='isort'
+  - python: 3.5
     env: DJANGO='django16'
   - python: 3.5
+    env: DJANGO='django17'
+  - python: 3.6
+    env: DJANGO='django16'
+  - python: 3.6
     env: DJANGO='django17'
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 - if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then export PYVER=py33; fi
 - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then export PYVER=py34; fi
 - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PYVER=py35; fi
+- if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PYVER=py36; fi
 - if [[ ${DJANGO}z != 'z' ]]; then export TOXENV=$PYVER-$DJANGO; fi
 script: COMMAND='coverage run' tox -e$TOXENV
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -18,16 +18,16 @@ directory or on ReadTheDocs: https://django-robots.readthedocs.io/
 Supported Django versions
 -------------------------
 
-* Django 1.6
-* Django 1.7
 * Django 1.8
 * Django 1.9
+* Django 1.10
+* Django 1.11
 
 Supported Python version
 ------------------------
 
-* Python 2.6, 2.7
-* Python 3.3, 3.4, 3.5
+* Python 2.7
+* Python 3.3, 3.4, 3.5, 3.6
 
 
 .. _install section: https://django-robots.readthedocs.io/en/latest/#installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,31 +2,33 @@
 Robots exclusion application for Django
 =======================================
 
+
 This is a basic Django application to manage robots.txt files following the
 `robots exclusion protocol`_, complementing the Django_ `Sitemap contrib app`_.
 
-The robots exclusion application consists of two database models which are
-tied together with a m2m relationship:
-
-* Rules_
-* URLs_
-
-.. _Django: http://www.djangoproject.com/
+For installation instructions, see the documentation `install section`_;
+for instructions on how to use this application, and on
+what it provides, see the file "overview.txt" in the "docs/"
+directory or on ReadTheDocs: https://django-robots.readthedocs.io/
 
 
 Supported Django versions
 -------------------------
 
-* Django 1.6
-* Django 1.7
 * Django 1.8
 * Django 1.9
+* Django 1.10
+* Django 1.11
 
 Supported Python version
 ------------------------
 
-* Python 2.6, 2.7
-* Python 3.3, 3.4, 3.5
+* Python 2.7
+* Python 3.3, 3.4, 3.5, 3.6
+
+
+.. _install section: https://django-robots.readthedocs.io/en/latest/#installation
+.. _Django: http://www.djangoproject.com/
 
 
 Installation
@@ -44,14 +46,14 @@ To install the sitemap app, then follow these steps:
 
 1. Add ``'robots'`` to your INSTALLED_APPS_ setting.
 2. Make sure ``'django.template.loaders.app_directories.Loader'``
-   is in your TEMPLATE_LOADERS_ setting. It's in there by default, so
+   is in your TEMPLATES setting. It's in there by default, so
    you'll only need to change this if you've changed that setting.
 3. Make sure you've installed the `sites framework`_.
 4. Run the ``syncdb`` or ``migrate`` management command (depening if you're
    using South or not)
 
 .. _INSTALLED_APPS: http://docs.djangoproject.com/en/dev/ref/settings/#installed-apps
-.. _TEMPLATE_LOADERS: http://docs.djangoproject.com/en/dev/ref/settings/#template-loaders
+.. _TEMPLATES: https://docs.djangoproject.com/en/dev/ref/settings/#templates
 .. _sites framework: http://docs.djangoproject.com/en/dev/ref/contrib/sites/
 
 Sitemaps
@@ -156,6 +158,14 @@ The default value is ``None`` (no caching).
 
 Changelog
 =========
+
+3.0 (unreleased)
+----------------
+
+- Dropped support for Django < 1.8
+- Added support for Django 1.10 / 1.11
+- Improved admin changeform
+- Fixed an error which resulted in doubling the scheme for sitemap
 
 2.0 (2016-02-28)
 ----------------

--- a/robots/views.py
+++ b/robots/views.py
@@ -2,6 +2,7 @@ from django.contrib.sites.models import Site
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.views.decorators.cache import cache_page
 from django.views.generic import ListView
+from django.contrib.sitemaps import views as sitemap_views
 
 from robots import settings
 from robots.models import Rule
@@ -24,10 +25,10 @@ class RuleList(ListView):
 
     def reverse_sitemap_url(self):
         try:
-            return reverse('django.contrib.sitemaps.views.index')
+            return reverse(sitemap_views.index)
         except NoReverseMatch:
             try:
-                return reverse('django.contrib.sitemaps.views.sitemap')
+                return reverse(sitemap_views.sitemap)
             except NoReverseMatch:
                 pass
 

--- a/robots/views.py
+++ b/robots/views.py
@@ -1,8 +1,8 @@
+from django.contrib.sitemaps import views as sitemap_views
 from django.contrib.sites.models import Site
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.views.decorators.cache import cache_page
 from django.views.generic import ListView
-from django.contrib.sitemaps import views as sitemap_views
 
 from robots import settings
 from robots.models import Rule

--- a/runtests.py
+++ b/runtests.py
@@ -26,6 +26,10 @@ DEFAULT_SETTINGS = dict(
         'django.middleware.locale.LocaleMiddleware',
         'django.middleware.common.CommonMiddleware',
     ],
+    TEMPLATES=[{
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    }]
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,11 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Framework :: Django',
-        'Framework :: Django :: 1.6',
-        'Framework :: Django :: 1.7',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
     ]
 )

--- a/tests/test_utils/urls.py
+++ b/tests/test_utils/urls.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+import django.contrib.sitemaps.views
+import django.views.i18n
+import django.views.static
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',  # NOQA
+    url(r'^media/(?P<path>.*)$', django.views.static.serve,  # NOQA
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
-    url(r'^jsi18n/(?P<packages>\S+?)/$', 'django.views.i18n.javascript_catalog'),  # NOQA
+    url(r'^jsi18n/(?P<packages>\S+?)/$', django.views.i18n.javascript_catalog),  # NOQA
     url(r'^admin/', include(admin.site.urls)),  # NOQA
     url(r'^/', include('robots.urls')),  # NOQA
-    url(r'^sitemap.xml$', 'django.contrib.sitemaps.views.sitemap', {'sitemaps': []}),
+    url(r'^sitemap.xml$', django.contrib.sitemaps.views.sitemap, {'sitemaps': []}),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,isort,py{35,34,27}-django{19},py{35,34,33,27}-django{18},py{34,33,27}-django{17,16},py{26}-django16
+envlist = pep8,isort,py{36,35,34,27}-django{111,110,19},py{36,35,34,33,27}-django{18}
 
 [testenv]
 commands = {env:COMMAND:python} runtests.py
@@ -9,8 +9,9 @@ deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django==1.11a1
     coverage
-    py26: unittest2
 
 [testenv:isort]
 deps = isort


### PR DESCRIPTION
Django < 1.8 are no longer supported upstream, I see no reason to keep them