### PR TITLE
Refactor settings to make possible override in settings

### DIFF
--- a/robots/settings.py
+++ b/robots/settings.py
@@ -1,13 +1,21 @@
+import sys
+
 from django.conf import settings
 
-#: A list of one or more sitemaps to inform robots about:
-SITEMAP_URLS = []
-SITEMAP_URLS.extend(getattr(settings, 'ROBOTS_SITEMAP_URLS', []))
 
-USE_SITEMAP = getattr(settings, 'ROBOTS_USE_SITEMAP', True)
+class Settings(object):
+    defaults = {
+        #: A list of one or more sitemaps to inform robots about:
+        'SITEMAP_URLS': ('ROBOTS_SITEMAP_URLS', []),
+        'USE_SITEMAP': ('ROBOTS_USE_SITEMAP', True),
+        'USE_HOST': ('ROBOTS_USE_HOST', True),
+        'CACHE_TIMEOUT': ('ROBOTS_CACHE_TIMEOUT', None),
+        'SITE_BY_REQUEST': ('ROBOTS_SITE_BY_REQUEST', False),
+    }
 
-USE_HOST = getattr(settings, 'ROBOTS_USE_HOST', True)
+    def __getattr__(self, attribute):
+        if attribute in self.defaults:
+            return getattr(settings, *self.defaults[attribute])
 
-CACHE_TIMEOUT = getattr(settings, 'ROBOTS_CACHE_TIMEOUT', None)
 
-SITE_BY_REQUEST = getattr(settings, 'ROBOTS_SITE_BY_REQUEST', False)
+sys.modules[__name__] = Settings()


### PR DESCRIPTION
This refactor the settings to make easy to override by using https://docs.djangoproject.com/en/1.10/topics/testing/tools/#overriding-settings

Trick by Guido Van Rossum himself:
```
# module foo.py

import sys

class Foo:
    def funct1(self, <args>): <code>
    def funct2(self, <args>): <code>

sys.modules[__name__] = Foo()
```

See https://mail.python.org/pipermail/python-ideas/2012-May/014969.html