### PR TITLE
Fix documentation for including the URL patterns

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -100,7 +100,7 @@ Initialization
 To activate robots.txt generation on your Django site, add this line to your
 URLconf_::
 
-    (r'^robots\.txt$', include('robots.urls')),
+    url(r'^robots\.txt', include('robots.urls')),
 
 This tells Django to build a robots.txt when a robot accesses ``/robots.txt``.
 Then, please sync your database to create the necessary tables and create


### PR DESCRIPTION
Using python 3.5 and Django 1.10, adding the URL patterns as instructed in the docs doesn't work. Currently it raises an error:
`Your URL pattern ('^robots\\.txt', (<module 'robots.urls' from '/home/vagrant/.pyenv/versions/3.5.2/lib/python3.5/site-packages/robots/urls.py'>, None, None)) is invalid. Ensure that urlpatterns is a list of url() instances.`

After adding the `url()` call, there is still a warning raised:
`?: (urls.W001) Your URL pattern '^robots\.txt$' uses include with a regex ending with a '$'. Remove the dollar from the regex to avoid problems including URLs.`