### PR TITLE
Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,15 @@ python:
 - 3.6
 - 3.5
 - 3.4
-- 3.3
 - 2.7
 env:
   matrix:
   - TOXENV='pep8'
   - TOXENV='isort'
   - DJANGO='django111'
-  - DJANGO='django110'
-  - DJANGO='django19'
-  - DJANGO='django18'
 install:
 - pip install -U tox>=1.8 codecov
 - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi
-- if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]]; then export PYVER=py33; fi
 - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then export PYVER=py34; fi
 - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PYVER=py35; fi
 - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PYVER=py36; fi
@@ -31,16 +26,6 @@ matrix:
     env: TOXENV='pep8'
   - python: 2.7
     env: TOXENV='isort'
-  - python: 3.3
-    env: DJANGO='django19'
-  - python: 3.3
-    env: DJANGO='django110'
-  - python: 3.3
-    env: DJANGO='django111'
-  - python: 3.3
-    env: TOXENV='pep8'
-  - python: 3.3
-    env: TOXENV='isort'
   - python: 3.4
     env: TOXENV='pep8'
   - python: 3.4
@@ -49,14 +34,6 @@ matrix:
     env: TOXENV='pep8'
   - python: 3.5
     env: TOXENV='isort'
-  - python: 3.5
-    env: DJANGO='django16'
-  - python: 3.5
-    env: DJANGO='django17'
-  - python: 3.6
-    env: DJANGO='django16'
-  - python: 3.6
-    env: DJANGO='django17'
 deploy:
   provider: pypi
   user: jazzband
@@ -66,4 +43,4 @@ deploy:
   on:
     tags: true
     repo: jazzband/django-robots
-    condition: "$TOXENV = py27-django19"
+    condition: "$TOXENV = py27-django111"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TOXENV='pep8'
   - TOXENV='isort'
   - DJANGO='django111'
+  - DJANGO='django200'
 install:
 - pip install -U tox>=1.8 codecov
 - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
     env: TOXENV='pep8'
   - python: 2.7
     env: TOXENV='isort'
+  - python: 2.7
+    env: DJANGO='django200'
   - python: 3.4
     env: TOXENV='pep8'
   - python: 3.4

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ directory or on ReadTheDocs: https://django-robots.readthedocs.io/
 Supported Django versions
 -------------------------
 
+* Django 2.0
 * Django 1.11
 
 Older Django versions, 1.6 to 1.10, use ``django-robots==3.0``.

--- a/README.rst
+++ b/README.rst
@@ -14,21 +14,18 @@ for instructions on how to use this application, and on
 what it provides, see the file "overview.txt" in the "docs/"
 directory or on ReadTheDocs: https://django-robots.readthedocs.io/
 
-
 Supported Django versions
 -------------------------
 
-* Django 1.8
-* Django 1.9
-* Django 1.10
 * Django 1.11
+
+Older Django versions, 1.6 to 1.10, use ``django-robots==3.0``.
 
 Supported Python version
 ------------------------
 
 * Python 2.7
-* Python 3.3, 3.4, 3.5, 3.6
-
+* Python 3.4, 3.5, 3.6
 
 .. _install section: https://django-robots.readthedocs.io/en/latest/#installation
 .. _robots exclusion protocol: http://en.wikipedia.org/wiki/Robots_exclusion_standard

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,16 +15,16 @@ directory or on ReadTheDocs: https://django-robots.readthedocs.io/
 Supported Django versions
 -------------------------
 
-* Django 1.8
-* Django 1.9
-* Django 1.10
+* Django 2.0
 * Django 1.11
+
+Older Django versions, 1.6 to 1.10, use ``django-robots==3.0``.
 
 Supported Python version
 ------------------------
 
 * Python 2.7
-* Python 3.3, 3.4, 3.5, 3.6
+* Python 3.4, 3.5, 3.6
 
 
 .. _install section: https://django-robots.readthedocs.io/en/latest/#installation

--- a/robots/views.py
+++ b/robots/views.py
@@ -1,11 +1,16 @@
+import django
 from django.contrib.sitemaps import views as sitemap_views
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import NoReverseMatch, reverse
 from django.views.decorators.cache import cache_page
 from django.views.generic import ListView
 
 from robots import settings
 from robots.models import Rule
+
+if django.VERSION[:2] >= (2, 0):
+    from django.urls import NoReverseMatch, reverse
+else:
+    from django.core.urlresolvers import NoReverseMatch, reverse
 
 
 class RuleList(ListView):

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,10 @@ setup(
         'Topic :: Software Development',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
-        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
     ]
 )

--- a/tests/base.py
+++ b/tests/base.py
@@ -28,7 +28,7 @@ class BaseTest(TestCase):
         if secure:
             request.environ['SERVER_PORT'] = str('443')
             request.environ['wsgi.url_scheme'] = str('https')
-        if user.is_authenticated():
+        if user.is_authenticated:
             request.session[SESSION_KEY] = user._meta.pk.value_to_string(user)
         request.cookies = SimpleCookie()
         request.errors = StringIO()

--- a/tests/test_utils/urls.py
+++ b/tests/test_utils/urls.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import django
-
 import django.contrib.sitemaps.views
 import django.views.i18n
 import django.views.static

--- a/tests/test_utils/urls.py
+++ b/tests/test_utils/urls.py
@@ -13,7 +13,6 @@ from django.views.decorators.cache import cache_page
 urlpatterns = [
     url(r'^media/(?P<path>.*)$', django.views.static.serve,  # NOQA
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
-    url(r'^jsi18n/(?P<packages>\S+?)/$', django.views.i18n.javascript_catalog),  # NOQA
     url(r'^admin/', include(admin.site.urls)),  # NOQA
     url(r'^/', include('robots.urls')),  # NOQA
     url(r'^sitemap.xml$', sitemap_view, {'sitemaps': []}),

--- a/tests/test_utils/urls.py
+++ b/tests/test_utils/urls.py
@@ -13,7 +13,7 @@ from django.views.decorators.cache import cache_page
 urlpatterns = [
     url(r'^media/(?P<path>.*)$', django.views.static.serve,  # NOQA
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
-    url(r'^admin/', include(admin.site.urls)),  # NOQA
+    url(r'^admin/', admin.site.urls),  # NOQA
     url(r'^/', include('robots.urls')),  # NOQA
     url(r'^sitemap.xml$', sitemap_view, {'sitemaps': []}),
     url(r'^other/sitemap.xml$', cache_page(60)(sitemap_view), {'sitemaps': []}, name='cached-sitemap'),

--- a/tests/test_utils/urls.py
+++ b/tests/test_utils/urls.py
@@ -1,14 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+import django
+
 import django.contrib.sitemaps.views
 import django.views.i18n
 import django.views.static
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.sitemaps.views import sitemap as sitemap_view
 from django.views.decorators.cache import cache_page
+
+if django.VERSION[:2] >= (2, 0):
+    from django.urls import include, re_path as url
+else:
+    from django.conf.urls import include, url
 
 urlpatterns = [
     url(r'^media/(?P<path>.*)$', django.views.static.serve,  # NOQA

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = pep8,isort,py{36,35,34,27}-django{111}
+envlist = pep8,isort,py{36,35,34}-django{200},py{36,35,34,27}-django{111}
 
 [testenv]
 commands = {env:COMMAND:python} runtests.py
 deps =
     -r{toxinidir}/requirements-test.txt
     django111: Django>=1.11,<2.0
+    django200: Django>=2.0,<2.1
     coverage
 
 [testenv:isort]

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,10 @@
 [tox]
-envlist = pep8,isort,py{36,35,34,27}-django{111,110,19},py{36,35,34,33,27}-django{18}
+envlist = pep8,isort,py{36,35,34,27}-django{111}
 
 [testenv]
 commands = {env:COMMAND:python} runtests.py
 deps =
     -r{toxinidir}/requirements-test.txt
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     coverage
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
-    django111: Django==1.11a1
+    django111: Django>=1.11,<2.0
     coverage
 
 [testenv:isort]


### PR DESCRIPTION
See https://github.com/jazzband/django-robots/issues/81#issue-280182346

Fixes include:

- Dropping support for 1.10 and below (pending confirmation at #82, preliminarily added)
- Fixes for URL imports

  - Fix ``javascript_catalog`` (reasons: unused in tests, rm'd in django 2.0)
  - ``include()`` style fixes for admin.site.urls
  - Conditional importing of url modules for backward compatibility
- Fixes for ``.is_authenticated()``
- Update tox and travis to test 2.0
- Update trove classifiers and README