### PR TITLE
Use gettext_lazy for Python 3 code

### DIFF
--- a/src/robots/admin.py
+++ b/src/robots/admin.py
@@ -1,12 +1,13 @@
 import sys
 
 from django.contrib import admin
+from robots.forms import RuleAdminForm
+from robots.models import Rule, Url
+
 if sys.version_info[0] == 2:
     from django.utils.translation import ugettext_lazy as _
 else:
     from django.utils.translation import gettext_lazy as _
-from robots.forms import RuleAdminForm
-from robots.models import Rule, Url
 
 
 class RuleAdmin(admin.ModelAdmin):

--- a/src/robots/admin.py
+++ b/src/robots/admin.py
@@ -1,5 +1,10 @@
+import sys
+
 from django.contrib import admin
-from django.utils.translation import ugettext_lazy as _
+if sys.version_info[0] == 2:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 from robots.forms import RuleAdminForm
 from robots.models import Rule, Url
 

--- a/src/robots/forms.py
+++ b/src/robots/forms.py
@@ -1,5 +1,10 @@
+import sys
+
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+if sys.version_info[0] == 2:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 from robots.models import Rule
 
 

--- a/src/robots/forms.py
+++ b/src/robots/forms.py
@@ -1,11 +1,12 @@
 import sys
 
 from django import forms
+from robots.models import Rule
+
 if sys.version_info[0] == 2:
     from django.utils.translation import ugettext_lazy as _
 else:
     from django.utils.translation import gettext_lazy as _
-from robots.models import Rule
 
 
 class RuleAdminForm(forms.ModelForm):

--- a/src/robots/models.py
+++ b/src/robots/models.py
@@ -3,11 +3,12 @@ import sys
 from django.contrib.sites.models import Site
 from django.db import models
 from django.utils.text import get_text_list
+from six import python_2_unicode_compatible, u
+
 if sys.version_info[0] == 2:
     from django.utils.translation import ugettext_lazy as _
 else:
     from django.utils.translation import gettext_lazy as _
-from six import python_2_unicode_compatible, u
 
 
 @python_2_unicode_compatible

--- a/src/robots/models.py
+++ b/src/robots/models.py
@@ -1,7 +1,12 @@
+import sys
+
 from django.contrib.sites.models import Site
 from django.db import models
 from django.utils.text import get_text_list
-from django.utils.translation import ugettext_lazy as _
+if sys.version_info[0] == 2:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 from six import python_2_unicode_compatible, u
 
 


### PR DESCRIPTION
I upgraded a project of ours to Python 3.8 and started seeing this deprecation warning: `django.utils.deprecation.RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().`. According to the [Django docs](https://docs.djangoproject.com/en/3.0/topics/i18n/translation/#standard-translation), `ugettext_lazy` and `gettext_lazy` are interchangable for Python 3. This PR should address that deprecation warning by keeping `ugettext_lazy` for Python 2.x and using `gettext_lazy` in Python 3. 