### PR TITLE
Updated Supported Python Versions when testing against Django Master

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     # list of supported Django/Python versions:
     # https://docs.djangoproject.com/en/3.1/faq/install/#what-python-version-can-i-use-with-django
-    py{36,37,38,39}-django{22,30,31,master}
+    py{36,37,38,39}-django{22,30,31}
+    py{38,39}-django{master}
     py38-{lint,docs}
 
 [gh-actions]


### PR DESCRIPTION
Django has now [dropped support](https://github.com/django/django/commit/ec0ff406311de88f4e2a135d784363424fe602aa) for Python 3.6 and 3.7 on it's main branch.