### PR TITLE
Django migrations for 5.0

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,7 +7,7 @@ INSTALLED_APPS = [
     "robots",
 ]
 
-DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3"}}
+DATABASES = {"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}}
 
 ROOT_URLCONF = "tests.urls"
 


### PR DESCRIPTION
#124

- tests: Use :memory: so it runs without erroring
- Canonical way to generate migrations for package

  `env PYTHONPATH=. DJANGO_SETTINGS_MODULE=tests.settings django-admin makemigrations robots`
- Add migration