### PR TITLE
Solve MakeMigration issue with MySql

### DIFF
--- a/src/robots/migrations/0002_alter_id_fields.py
+++ b/src/robots/migrations/0002_alter_id_fields.py
@@ -13,14 +13,14 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="rule",
             name="id",
-            field=models.BigAutoField(
+            field=models.AutoField(
                 auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
             ),
         ),
         migrations.AlterField(
             model_name="url",
             name="id",
-            field=models.BigAutoField(
+            field=models.AutoField(
                 auto_created=True, primary_key=True, serialize=False, verbose_name="ID"
             ),
         ),


### PR DESCRIPTION
django-robots version 5.0
I am using above version of django-robots. When database is SQLite, things are working fine but when the database is MySQL, it gives following error while running migrate command.

**Error:** django.db.utils.OperationalError: (3780, "Referencing column 'rule_id' and referenced column 'id' in foreign key constraint 'robots_rule_sites_rule_id_7921a799_fk_robots_rule_id' are incompatible.")

I investigate and figure out that the BigAutoField is causing the problem.