### PR TITLE
Fix pkg_resources deprecation warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: check-added-large-files
       - id: debug-statements
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: "5.12.0"
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/flake8

--- a/src/robots/__init__.py
+++ b/src/robots/__init__.py
@@ -1,8 +1,10 @@
 try:
     from importlib.metadata import version
+
     __version__ = version("django-robots")
 except ImportError:
     from pkg_resources import get_distribution
+
     __version__ = get_distribution("django-robots").version
 
 # needed for Django<3.2

--- a/src/robots/__init__.py
+++ b/src/robots/__init__.py
@@ -1,6 +1,9 @@
-from pkg_resources import get_distribution
-
-__version__ = get_distribution("django-robots").version
+try:
+    from importlib.metadata import version
+    __version__ = version("django-robots")
+except ImportError:
+    from pkg_resources import get_distribution
+    __version__ = get_distribution("django-robots").version
 
 # needed for Django<3.2
 default_app_config = "robots.apps.RobotsConfig"

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ envlist =
     # list of supported Django/Python versions:
     # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
     py{36,37,38,39,310}-dj{22,31,32}
-    py{38,39,310}-dj{40}
-    py{38,39,310}-djmain
+    py{38,39,310}-dj{40,41}
+    py{38,39,310,311}-dj42
+    py{310,311,312}-djmain
     py38-{lint,docs}
 
 [gh-actions]
@@ -13,6 +14,8 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
 
 [testenv]
 usedevelop = true
@@ -28,7 +31,9 @@ deps =
     dj22: django>=2.2,<2.3
     dj31: django>=3.1,<3.2
     dj32: django>=3.2,<3.3
-    dj40: django>=4.0a1,<4.1
+    dj40: django>=4.0,<4.1
+    dj41: django>=4.1,<4.2
+    dj42: django>=4.2,<4.3
     djmain: https://github.com/django/django/archive/main.tar.gz
 
 [testenv:py38-lint]


### PR DESCRIPTION
Running with Python 3.11 generates the following warning:

```
python3.11/site-packages/robots/__init__.py:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import get_distribution
```

This PR attempts to first import `importlib.metadata.version` before falling back to using `pkg_resources.get_distribution`.