### PR TITLE
Remove default_app_config in robots/ __init__.py

### DIFF
--- a/src/robots/__init__.py
+++ b/src/robots/__init__.py
@@ -6,6 +6,3 @@ except ImportError:
     from pkg_resources import get_distribution
 
     __version__ = get_distribution("django-robots").version
-
-# needed for Django<3.2
-default_app_config = "robots.apps.RobotsConfig"


### PR DESCRIPTION
Was only needed for django < 3.2 which are all EOL
With newer versions of django it's issueing a RemovedInDjango41Warning